### PR TITLE
Fix initialization issue for heater device type due to missing state …

### DIFF
--- a/homewizard_climate_ws/model/climate_device_state.py
+++ b/homewizard_climate_ws/model/climate_device_state.py
@@ -53,8 +53,9 @@ def diff_states(
 ) -> str:
     result = ""
     for k, v in first_state.to_dict().items():
-        second_value = second_state.to_dict().get(k)
-        if v != second_value:
-            result += f"{k}: {v} -> {second_value}, "
+        if k in second_state.to_dict():
+            second_value = second_state.to_dict().get(k)
+            if v != second_value:
+                result += f"{k}: {v} -> {second_value}, "
 
     return result

--- a/homewizard_climate_ws/ws/hw_websocket.py
+++ b/homewizard_climate_ws/ws/hw_websocket.py
@@ -211,8 +211,13 @@ class HomeWizardClimateWebSocket:
                 self._on_initialized(self._device)
 
         self._LOGGER.debug(f"Received full device update: {received_message}")
+        state = received_message.get("state")
+        # Fill-in missing state entries using default values
+        for k, v in default_state().to_dict().items():
+            if k not in state:
+                state[k] = v
         self._update_last_state(
-            HomeWizardClimateDeviceState.from_dict(received_message.get("state"))
+            HomeWizardClimateDeviceState.from_dict(state)
         )
 
     def _handle_state_update(self, received_message: dict) -> None:


### PR DESCRIPTION
Heater devices have issues with initialization. This is caused by the `HomeWizardClimateDeviceState` being constructed from a dict with missing keys. This PR populates those entries using the default value.

This is based on this PR on the original mepla repo: https://github.com/mepla/homewizard-climate-websocket/pull/2/commits
But with some edits to actually make the suggested changes work (probably a line of code missing in the commit: there was a `state` variable used but never created)

Please approve this PR, bump package version and bump requirements in https://github.com/dennis1804/homewizard-climate-hass as well.
